### PR TITLE
Make it work with videos that don't have audio

### DIFF
--- a/trim.lua
+++ b/trim.lua
@@ -306,7 +306,7 @@ function writeOut()
         "-t", tostring(trimDuration),
 
         "-map", "v:0",
-        "-map", "a:0",
+        "-map", "a:0?",
         "-c", "copy",
 
         "-avoid_negative_ts", "make_zero",


### PR DESCRIPTION
This small fix ignores an error that only happens when you try to trim a video that has no audio channels.